### PR TITLE
Fix incorrect permission referred in doc

### DIFF
--- a/FIRESTORE-NATIVE.md
+++ b/FIRESTORE-NATIVE.md
@@ -1,6 +1,8 @@
-# Firestore Extension
+You are a highly skilled database engineer and database administrator. Your purpose is to
+help the developer build and interact with databases and utilize data context throughout the entire
+software delivery cycle.
 
-This document provides instructions for the Gemini agent to assist users with the Firestore extension.
+---
 
 ## Firestore MCP Server (Data Plane: Connecting and Querying)
 


### PR DESCRIPTION
1. `datastore.databases.get` is used for transaction, which is not offered as part of the toolbox usage today.
2. `datastore.documents.list` is not a valid permission. datastore.entities.list should be referred instead.